### PR TITLE
Disable hidden initiative inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -857,15 +857,23 @@
     let storedActiveCombatantId = null;
     let storedActiveNpcId = null;
 
+    function setFieldHiddenState(field, shouldHide) {
+      field.hidden = shouldHide;
+      field.setAttribute('aria-hidden', String(shouldHide));
+      field
+        .querySelectorAll('input, select, textarea, button')
+        .forEach((control) => {
+          control.disabled = shouldHide;
+        });
+    }
+
     function setFieldVisibility(mode) {
       const isManual = mode === 'manual';
       manualFields.forEach((field) => {
-        field.hidden = !isManual;
-        field.setAttribute('aria-hidden', String(!isManual));
+        setFieldHiddenState(field, !isManual);
       });
       autoFields.forEach((field) => {
-        field.hidden = isManual;
-        field.setAttribute('aria-hidden', String(isManual));
+        setFieldHiddenState(field, isManual);
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure the initiative tracker toggles the visibility and enabled state of manual and auto roll fields
- disable hidden inputs so only the appropriate controls are accessible for the selected roll mode

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daa025b45c83258da6f40e60a885d1