### PR TITLE
Improve mobile layout for player initiative view

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,20 @@
 
     body {
       margin: 0;
-      display: flex;
-      justify-content: center;
       min-height: 100vh;
       background: linear-gradient(135deg, #f0f4ff, #e3f8ff);
       padding: 2rem 1rem;
       box-sizing: border-box;
+    }
+
+    body.dm-view {
+      display: flex;
+      justify-content: center;
+    }
+
+    body.player-view {
+      display: block;
+      padding: 1.5rem 1rem;
     }
 
     .app {
@@ -32,6 +40,13 @@
       transition: opacity 0.3s ease;
     }
 
+    body.player-view .app {
+      padding: 1.75rem 1.25rem;
+      border-radius: 16px;
+      max-width: 560px;
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.08);
+    }
+
     h1 {
       text-align: center;
       margin-top: 0;
@@ -39,6 +54,12 @@
       font-size: 2.1rem;
       letter-spacing: 0.05em;
       color: #274060;
+    }
+
+    body.player-view h1 {
+      text-align: left;
+      font-size: 1.75rem;
+      margin-bottom: 1.5rem;
     }
 
     h2 {
@@ -51,11 +72,19 @@
       gap: 1.5rem;
     }
 
+    body.player-view .section {
+      gap: 1.25rem;
+    }
+
     .form-grid {
       display: grid;
       gap: 1rem;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       align-items: end;
+    }
+
+    body.player-view .form-grid {
+      grid-template-columns: 1fr;
     }
 
     .field {
@@ -111,6 +140,12 @@
       flex-wrap: wrap;
     }
 
+    body.player-view .radio-group {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.75rem;
+    }
+
     .radio-option {
       display: flex;
       align-items: center;
@@ -135,6 +170,10 @@
       font-weight: 600;
       cursor: pointer;
       transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+
+    body.player-view button {
+      width: 100%;
     }
 
     button:hover {
@@ -238,6 +277,11 @@
       font-size: 0.9rem;
       color: #4a5d78;
       min-height: 1.1rem;
+    }
+
+    body.player-view .player-status {
+      min-height: 0;
+      text-align: left;
     }
 
     .error {
@@ -761,10 +805,18 @@
       .app {
         padding: 1.75rem;
       }
+
+      body.player-view {
+        padding: 1.25rem 0.75rem;
+      }
+
+      body.player-view .app {
+        padding: 1.5rem 1rem;
+      }
     }
   </style>
 </head>
-<body>
+<body class="dm-view">
   <main id="initiative-app" class="app" aria-labelledby="initiative-title">
     <h1 id="initiative-title">Initiative Tracker</h1>
     <section class="session-share" aria-label="Share player submission session">
@@ -1160,6 +1212,9 @@
       isPlayerView = false;
       prefilledPlayerSessionCode = '';
     }
+
+    document.body.classList.toggle('player-view', isPlayerView);
+    document.body.classList.toggle('dm-view', !isPlayerView);
 
     const combatants = [];
     let combatantCounter = 0;


### PR DESCRIPTION
## Summary
- add body classes that distinguish DM and player views and toggle them dynamically when loading the app
- tailor the player interface styling for narrow screens so forms stack cleanly and controls fill the viewport on mobile
- adjust responsive spacing to keep the player view comfortable on phones while leaving the DM layout unchanged

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbb126e5f08325a54af199033550e6